### PR TITLE
Enable standard linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,4 @@ linters:
     - misspell
     - typecheck
     - errcheck
-run:
-  skip-dirs:
-    - modelplugin
+

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ deps: # @HELP ensure that the required dependencies are in place
 	bash -c "diff -u <(echo -n) <(git diff go.sum)"
 
 linters: # @HELP examines Go source code and reports coding problems
-	# golangci-lint run
+	golangci-lint run
 
 license_check: # @HELP examine and ensure license headers exist
 	./build/licensing/boilerplate.py -v

--- a/cmd/onos-topo/onos-topo.go
+++ b/cmd/onos-topo/onos-topo.go
@@ -37,30 +37,18 @@ import (
 	log "k8s.io/klog"
 )
 
-type arrayFlags []string
-
-func (i *arrayFlags) String() string {
-	return "my string representation"
-}
-
-func (i *arrayFlags) Set(value string) error {
-	*i = append(*i, value)
-	return nil
-}
-
 // The main entry point
 func main() {
 	caPath := flag.String("caPath", "", "path to CA certificate")
 	keyPath := flag.String("keyPath", "", "path to client private key")
 	certPath := flag.String("certPath", "", "path to client certificate")
-	var err error
 
 	//lines 93-109 are implemented according to
 	// https://github.com/kubernetes/klog/blob/master/examples/coexist_glog/coexist_glog.go
 	// because of libraries importing glog. With glog import we can't call log.InitFlags(nil) as per klog readme
 	// thus the alsologtostderr is not set properly and we issue multiple logs.
 	// Calling log.InitFlags(nil) throws panic with error `flag redefined: log_dir`
-	err = flag.Set("alsologtostderr", "true")
+	err := flag.Set("alsologtostderr", "true")
 	if err != nil {
 		log.Error("Cant' avoid double Error logging ", err)
 	}
@@ -74,7 +62,7 @@ func main() {
 		f2 := klogFlags.Lookup(f1.Name)
 		if f2 != nil {
 			value := f1.Value.String()
-			f2.Value.Set(value)
+			_ = f2.Value.Set(value)
 		}
 	})
 	log.Info("Starting onos-topo")

--- a/pkg/cli/command/completion.go
+++ b/pkg/cli/command/completion.go
@@ -53,7 +53,7 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	zshHead := "#compdef onos\n"
 
-	out.Write([]byte(zshHead))
+	_, _ = out.Write([]byte(zshHead))
 
 	zshInitialization := `
 __onos_bash_source() {
@@ -180,11 +180,11 @@ __onos_convert_bash_to_zsh() {
 	-e "s/\\\$(type${RWORD}/\$(__onos_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `
-	out.Write([]byte(zshInitialization))
+	_, _ = out.Write([]byte(zshInitialization))
 
 	buf := new(bytes.Buffer)
-	cmd.GenBashCompletion(buf)
-	out.Write(buf.Bytes())
+	_ = cmd.GenBashCompletion(buf)
+	_, _ = out.Write(buf.Bytes())
 
 	zshTail := `
 BASH_COMPLETION_EOF
@@ -192,6 +192,6 @@ BASH_COMPLETION_EOF
 __onos_bash_source <(__onos_convert_bash_to_zsh)
 _complete onos 2>/dev/null
 `
-	out.Write([]byte(zshTail))
+	_, _ = out.Write([]byte(zshTail))
 	return nil
 }

--- a/pkg/cli/command/config.go
+++ b/pkg/cli/command/config.go
@@ -139,15 +139,6 @@ func newInitCommand() *cobra.Command {
 	}
 }
 
-func setConfig(key string, value string) error {
-	viper.Set(key, value)
-	return viper.WriteConfig()
-}
-
-func getConfig(key string) string {
-	return viper.GetString(key)
-}
-
 func initConfig() {
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
@@ -163,5 +154,5 @@ func initConfig() {
 		viper.AddConfigPath(".")
 	}
 
-	viper.ReadInConfig()
+	_ = viper.ReadInConfig()
 }

--- a/pkg/cli/command/root.go
+++ b/pkg/cli/command/root.go
@@ -17,10 +17,8 @@ package command
 
 import (
 	"github.com/onosproject/onos-config/pkg/certs"
-	"github.com/onosproject/onos-topo/pkg/northbound"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 )
 
 // GetRootCommand returns the root CLI command.
@@ -39,23 +37,12 @@ func GetRootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP("certPath", "c", viper.GetString("certPath"), "path to client certificate")
 	cmd.PersistentFlags().String("config", "", "config file (default: $HOME/.onos/config.yaml)")
 
-	viper.BindPFlag("address", cmd.PersistentFlags().Lookup("address"))
-	viper.BindPFlag("keyPath", cmd.PersistentFlags().Lookup("keyPath"))
-	viper.BindPFlag("certPath", cmd.PersistentFlags().Lookup("certPath"))
+	_ = viper.BindPFlag("address", cmd.PersistentFlags().Lookup("address"))
+	_ = viper.BindPFlag("keyPath", cmd.PersistentFlags().Lookup("keyPath"))
+	_ = viper.BindPFlag("certPath", cmd.PersistentFlags().Lookup("certPath"))
 
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(newConfigCommand())
 	cmd.AddCommand(newCompletionCommand())
 	return cmd
-}
-
-func getConnection(cmd *cobra.Command) *grpc.ClientConn {
-	keyPath := getConfig("keyPath")
-	certPath := getConfig("certPath")
-	address := getConfig("address")
-	opts, err := certs.HandleCertArgs(&keyPath, &certPath)
-	if err != nil {
-		ExitWithError(ExitError, err)
-	}
-	return northbound.Connect(address, opts...)
 }

--- a/pkg/northbound/server.go
+++ b/pkg/northbound/server.go
@@ -20,13 +20,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/certs"
 	"google.golang.org/grpc/credentials"
 	"io/ioutil"
 	log "k8s.io/klog"
 	"net"
-	"sync"
-
-	"github.com/onosproject/onos-config/pkg/certs"
 
 	"google.golang.org/grpc"
 )
@@ -40,7 +38,6 @@ type Service interface {
 type Server struct {
 	cfg      *ServerConfig
 	services []Service
-	mu       sync.Mutex
 }
 
 // ServerConfig comprises a set of server configuration options.


### PR DESCRIPTION
Enables standard set of linters
Fixes lint related errors
Cleans up unneeded stuff from glangci-lint configuration
