### PR TITLE
Add onos CLI to debug image

### DIFF
--- a/build/onos-topo-debug/Dockerfile
+++ b/build/onos-topo-debug/Dockerfile
@@ -5,13 +5,15 @@ FROM onosproject/onos-topo-base:$ONOS_TOPO_BASE_VERSION as base
 FROM golang:1.12.6-alpine3.9 as debugBuilder
 
 RUN apk upgrade --update --no-cache && apk add git && \
-    go get -u github.com/go-delve/delve/cmd/dlv
+    go get -u github.com/go-delve/delve/cmd/dlv && \
+    go get -u github.com/onosproject/onos-cli/cmd/onos
 
 FROM alpine:3.9
 
 RUN apk upgrade --update --no-cache && apk add bash bash-completion libc6-compat
 
 COPY --from=base /go/src/github.com/onosproject/onos-topo/build/_output/onos-topo-debug /usr/local/bin/onos-topo
+COPY --from=debugBuilder /go/bin/onos /usr/local/bin/onos
 COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-topo-debug && \

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/atomix/atomix-go-client v0.0.0-20190807011524-58b4352273d7
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
-	github.com/golang/protobuf v1.3.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onosproject/onos-config v0.0.0-20190715180819-079d3a8dc433
 	github.com/onosproject/onos-control v0.0.0-20190715190020-706a2ee0d37b // indirect


### PR DESCRIPTION
Add the new `onos` CLI to the debug image for usage in reconfiguring the cluster via the topo service.