### PR TITLE
Validate device objects in device service

### DIFF
--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -128,6 +128,9 @@ func getAddDeviceCommand() *cobra.Command {
 	cmd.Flags().Bool("insecure", false, "whether to enable skip verification")
 	cmd.Flags().Duration("timeout", 30*time.Second, "the device connection timeout")
 	cmd.Flags().StringToString("attributes", map[string]string{}, "an arbitrary mapping of device attributes")
+
+	_ = cmd.MarkFlagRequired("version")
+	_ = cmd.MarkFlagRequired("type")
 	return cmd
 }
 

--- a/pkg/northbound/device/service.go
+++ b/pkg/northbound/device/service.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	defaultTimeout = 30 * time.Second
-	deviceNamePattern = `^[a-zA-Z0-9\-:_]{4,40}$`
+	defaultTimeout       = 30 * time.Second
+	deviceNamePattern    = `^[a-zA-Z0-9\-:_]{4,40}$`
 	deviceAddressPattern = `^[a-zA-Z0-9\-_]+:[0-9]+$`
 	deviceVersionPattern = `^(\d+\.\d+\.\d+)$`
 )


### PR DESCRIPTION
This PR adds validation for `Device` objects when added/updated in the device service implementation. The validation is mostly taken from onos-config. Additionally, the `device` CLI commands are updated to mark required fields as required flags. And a default timeout of 30 seconds is applied to devices to avoid hanging connections.