### PR TITLE
Ensure 'device not found' error is returned when store is empty

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/pkg/northbound/device/service_test.go
+++ b/pkg/northbound/device/service_test.go
@@ -54,6 +54,11 @@ func TestLocalServer(t *testing.T) {
 
 	client := NewDeviceServiceClient(conn)
 
+	_, err = client.Get(context.Background(), &GetRequest{
+		ID: ID("none"),
+	})
+	assert.Error(t, err, "device not found")
+
 	_, err = client.Add(context.Background(), &AddRequest{
 		Device: &Device{
 			ID:      ID("foo"),

--- a/pkg/northbound/device/store.go
+++ b/pkg/northbound/device/store.go
@@ -125,6 +125,8 @@ func (s *atomixStore) Load(deviceID ID) (*Device, error) {
 	kv, err := s.devices.Get(ctx, string(deviceID))
 	if err != nil {
 		return nil, err
+	} else if kv == nil {
+		return nil, nil
 	}
 	return decodeDevice(kv.Key, kv.Value, kv.Version)
 }


### PR DESCRIPTION
Fixes https://github.com/onosproject/onos-cli/issues/10