### PR TITLE
Add persistent configuration and commands for CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/atomix/atomix-go-node v0.0.0-20191021234659-c841a97bec89
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -17,24 +17,16 @@ package cli
 import (
 	"crypto/tls"
 	"github.com/onosproject/onos-topo/pkg/certs"
-	"github.com/spf13/viper"
+	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
-const (
-	defaultAddress = "onos-topo:5150"
-)
-
 // getConnection returns a gRPC client connection to the topo service
-func getConnection() (*grpc.ClientConn, error) {
-	addressObj := viper.Get("address")
-	if addressObj == nil {
-		addressObj = defaultAddress
-	}
-	address := addressObj.(string)
-	certPath := viper.GetString("tls.certPath")
-	keyPath := viper.GetString("tls.keyPath")
+func getConnection(cmd *cobra.Command) (*grpc.ClientConn, error) {
+	address := getAddress(cmd)
+	certPath := getCertPath(cmd)
+	keyPath := getKeyPath(cmd)
 	var opts []grpc.DialOption
 	if certPath != "" && keyPath != "" {
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -21,10 +21,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	configFile = ""
-)
-
 const (
 	addressKey     = "address"
 	defaultAddress = "onos-topo:5150"
@@ -132,19 +128,15 @@ func getKeyPath(cmd *cobra.Command) string {
 }
 
 func initConfig() {
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
-	} else {
-		home, err := homedir.Dir()
-		if err != nil {
-			panic(err)
-		}
-
-		viper.SetConfigName("topo")
-		viper.AddConfigPath(home + "/.onos")
-		viper.AddConfigPath("/etc/onos")
-		viper.AddConfigPath(".")
+	home, err := homedir.Dir()
+	if err != nil {
+		panic(err)
 	}
 
-	viper.ReadInConfig()
+	viper.SetConfigName("topo")
+	viper.AddConfigPath(home + "/.onos")
+	viper.AddConfigPath("/etc/onos")
+	viper.AddConfigPath(".")
+
+	_ = viper.ReadInConfig()
 }

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -49,7 +49,7 @@ func addConfigFlags(cmd *cobra.Command) {
 func getConfigCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config {set,get,delete} [args]",
-		Short: "Read and update CLI configuration options",
+		Short: "Manage the CLI configuration",
 	}
 	cmd.AddCommand(newConfigGetCommand())
 	cmd.AddCommand(newConfigSetCommand())

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -1,0 +1,150 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	configFile = ""
+)
+
+const (
+	addressKey     = "address"
+	defaultAddress = "onos-topo:5150"
+
+	tlsCertPathKey = "tls.certPath"
+	tlsKeyPathKey  = "tls.keyPath"
+)
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+var configOptions = []string{
+	addressKey,
+	tlsCertPathKey,
+	tlsKeyPathKey,
+}
+
+func addConfigFlags(cmd *cobra.Command) {
+	viper.SetDefault(addressKey, defaultAddress)
+	cmd.PersistentFlags().StringP("address", "a", viper.GetString(addressKey), "the onos-topo service address")
+	cmd.PersistentFlags().String("tls-key-path", viper.GetString(tlsKeyPathKey), "the path to the TLS key")
+	cmd.PersistentFlags().String("tls-cert-path", viper.GetString(tlsCertPathKey), "the path to the TLS certificate")
+}
+
+func getConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config {set,get,delete} [args]",
+		Short: "Read and update CLI configuration options",
+	}
+	cmd.AddCommand(newConfigGetCommand())
+	cmd.AddCommand(newConfigSetCommand())
+	cmd.AddCommand(newConfigDeleteCommand())
+	return cmd
+}
+
+func newConfigGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "get <key>",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: configOptions,
+		RunE:      runConfigGetCommand,
+	}
+}
+
+func runConfigGetCommand(_ *cobra.Command, args []string) error {
+	value := viper.Get(args[0])
+	fmt.Fprintln(GetOutput(), value)
+	return nil
+}
+
+func newConfigSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "set <key> <value>",
+		Args:      cobra.ExactArgs(2),
+		ValidArgs: configOptions,
+		RunE:      runConfigSetCommand,
+	}
+}
+
+func runConfigSetCommand(_ *cobra.Command, args []string) error {
+	viper.Set(args[0], args[1])
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+
+	value := viper.Get(args[0])
+	fmt.Fprintln(GetOutput(), value)
+	return nil
+}
+
+func newConfigDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "delete <key>",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: configOptions,
+		RunE:      runConfigDeleteCommand,
+	}
+}
+
+func runConfigDeleteCommand(_ *cobra.Command, args []string) error {
+	viper.Set(args[0], nil)
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+
+	value := viper.Get(args[0])
+	fmt.Fprintln(GetOutput(), value)
+	return nil
+}
+
+func getAddress(cmd *cobra.Command) string {
+	address, _ := cmd.PersistentFlags().GetString("address")
+	return address
+}
+
+func getCertPath(cmd *cobra.Command) string {
+	certPath, _ := cmd.PersistentFlags().GetString("tls-cert-path")
+	return certPath
+}
+
+func getKeyPath(cmd *cobra.Command) string {
+	keyPath, _ := cmd.PersistentFlags().GetString("tls-key-path")
+	return keyPath
+}
+
+func initConfig() {
+	if configFile != "" {
+		viper.SetConfigFile(configFile)
+	} else {
+		home, err := homedir.Dir()
+		if err != nil {
+			panic(err)
+		}
+
+		viper.SetConfigName("topo")
+		viper.AddConfigPath(home + "/.onos")
+		viper.AddConfigPath("/etc/onos")
+		viper.AddConfigPath(".")
+	}
+
+	viper.ReadInConfig()
+}

--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -43,7 +43,7 @@ func runGetDeviceCommand(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	noHeaders, _ := cmd.Flags().GetBool("no-headers")
 
-	conn, err := getConnection()
+	conn, err := getConnection(cmd)
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func runAddDeviceCommand(cmd *cobra.Command, args []string) error {
 		deviceTarget = id
 	}
 
-	conn, err := getConnection()
+	conn, err := getConnection(cmd)
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func getUpdateDeviceCommand() *cobra.Command {
 func runUpdateDeviceCommand(cmd *cobra.Command, args []string) error {
 	id := args[0]
 
-	conn, err := getConnection()
+	conn, err := getConnection(cmd)
 	if err != nil {
 		return nil
 	}
@@ -366,7 +366,7 @@ func getRemoveDeviceCommand() *cobra.Command {
 func runRemoveDeviceCommand(cmd *cobra.Command, args []string) error {
 	id := args[0]
 
-	conn, err := getConnection()
+	conn, err := getConnection(cmd)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func runWatchDeviceCommand(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	noHeaders, _ := cmd.Flags().GetBool("no-headers")
 
-	conn, err := getConnection()
+	conn, err := getConnection(cmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -14,7 +14,9 @@
 
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 // GetCommand returns the root command for the topo service
 func GetCommand() *cobra.Command {
@@ -22,6 +24,9 @@ func GetCommand() *cobra.Command {
 		Use: "topo {get,add,update,remove,watch} [args]",
 	}
 
+	addConfigFlags(cmd)
+
+	cmd.AddCommand(getConfigCommand())
 	cmd.AddCommand(getGetCommand())
 	cmd.AddCommand(getAddCommand())
 	cmd.AddCommand(getUpdateCommand())

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -62,6 +62,7 @@ func Test_SubCommands(t *testing.T) {
 		commandName   string
 		expectedShort string
 	}{
+		{commandName: "config", expectedShort: "Manage the CLI configuration"},
 		{commandName: "add", expectedShort: "Add a topology resource"},
 		{commandName: "get", expectedShort: "Get topology resources"},
 		{commandName: "remove", expectedShort: "Remove a topology resource"},


### PR DESCRIPTION
This PR addresses #62 by adding Viper integration to manage the onos-topo configuration. Configuration files are placed in a `~/onos/topo.yaml` configuration file. Other services can follow the pattern with `~/onos/config.yaml`, `~/onos/control.yaml`, etc.

Three commands are added to the CLI:
* `onos topo config get` returns the value of a configuration key
* `onos topo config set {key} {value}` sets the value of a key
* `onos topo config delete` deletes the persisted value of a key, reverting to its default