### PR TITLE
Fix indentation in partitionset.yaml

### DIFF
--- a/deployments/helm/onos-topo/templates/partitionset.yaml
+++ b/deployments/helm/onos-topo/templates/partitionset.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       size: {{ .Values.store.raft.partitionSize }}
       raft:
-         electionTimeoutMillis: 5000
-         heartbeatPeriodMillis: 1000
+        electionTimeoutMillis: 5000
+        heartbeatPeriodMillis: 1000
 {{- end }}


### PR DESCRIPTION
Because of the indentation in the `partitionset.yaml` file, the k8s API was not getting the correct values for the `raft` configuration for the `PartitionSet` resource.