### PR TITLE
Moving addres flag for service to service-address

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -25,14 +25,14 @@ const (
 	configDir  = ".onos"
 	configName = "topo"
 
-	addressKey     = "address"
+	addressKey     = "service-address"
 	defaultAddress = "onos-topo:5150"
 
 	tlsCertPathKey = "tls.certPath"
 	tlsKeyPathKey  = "tls.keyPath"
 	noTLSKey       = "no-tls"
 
-	addressFlag     = "address"
+	addressFlag     = "service-address"
 	tlsCertPathFlag = "tls-cert-path"
 	tlsKeyPathFlag  = "tls-key-path"
 	noTLSFlag       = "no-tls"
@@ -48,7 +48,7 @@ var configOptions = []string{
 func addConfigFlags(cmd *cobra.Command) {
 	viper.SetDefault(addressKey, defaultAddress)
 
-	cmd.PersistentFlags().StringP(addressFlag, "a", viper.GetString(addressKey), "the onos-topo service address")
+	cmd.PersistentFlags().String(addressFlag, viper.GetString(addressKey), "the onos-topo service address")
 	cmd.PersistentFlags().String(tlsCertPathFlag, viper.GetString(tlsCertPathKey), "the path to the TLS certificate")
 	cmd.PersistentFlags().String(tlsKeyPathFlag, viper.GetString(tlsKeyPathKey), "the path to the TLS key")
 	cmd.PersistentFlags().Bool(noTLSFlag, viper.GetBool(noTLSKey), "if present, do not use TLS")

--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -231,7 +231,7 @@ func runAddDeviceCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	Output("Added device %s", id)
+	Output("Added device %s \n", id)
 	return nil
 }
 

--- a/pkg/cli/device_test.go
+++ b/pkg/cli/device_test.go
@@ -84,7 +84,7 @@ func Test_AddDevice(t *testing.T) {
 	err := addDevice.Execute()
 	assert.NilError(t, err)
 	output := outputBuffer.String()
-	assert.Equal(t, output, "Added device test-device-1")
+	assert.Assert(t, strings.Contains(output, "Added device test-device-1"))
 }
 
 func Test_UpdateDevice(t *testing.T) {
@@ -105,7 +105,7 @@ func Test_UpdateDevice(t *testing.T) {
 	err := updateDevice.Execute()
 	assert.NilError(t, err)
 	output := outputBuffer.String()
-	assert.Equal(t, output, "Updated device test-device-1")
+	assert.Assert(t, strings.Contains(output, "Updated device test-device-1"))
 }
 
 func Test_RemoveDevice(t *testing.T) {
@@ -120,5 +120,5 @@ func Test_RemoveDevice(t *testing.T) {
 	err := removeDevice.Execute()
 	assert.NilError(t, err)
 	output := outputBuffer.String()
-	assert.Equal(t, output, "Removed device test-device-1")
+	assert.Assert(t, strings.Contains(output, "Removed device test-device-1"))
 }


### PR DESCRIPTION
the --address general flag was conflicting with the device --address flag.
Has been moved to --service-address to avoid.
Removed the a shorthand.