### PR TITLE
In topo, extend device-version regex to allow e.g. "19.3.1.8"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ images: build onos-topo-docker onos-topo-debug-docker onos-topo-tests-docker
 kind: # @HELP build Docker images and add them to the currently configured kind cluster
 kind: images
 	@if [ "`kind get clusters`" = '' ]; then echo "no kind cluster found" && exit 1; fi
-	kind load docker-image onosproject/onos-topo:${ONOS_TOPO_DEBUG_VERSION}
+	kind load docker-image onosproject/onos-topo:${ONOS_TOPO_VERSION}
 	kind load docker-image onosproject/onos-topo-tests:${ONOS_TOPO_VERSION}
 
 all: build images

--- a/pkg/northbound/device/service.go
+++ b/pkg/northbound/device/service.go
@@ -31,7 +31,7 @@ const (
 	defaultTimeout       = 5 * time.Second
 	deviceNamePattern    = `^[a-zA-Z0-9\-:_]{4,40}$`
 	deviceAddressPattern = `^[a-zA-Z0-9\-_\.]+:[0-9]+$`
-	deviceVersionPattern = `^(\d+\.\d+\.\d+)$`
+	deviceVersionPattern = `^(\d+(\.\d+){0,3})$`
 )
 
 // NewService returns a new device Service

--- a/pkg/northbound/device/service.go
+++ b/pkg/northbound/device/service.go
@@ -145,7 +145,7 @@ func (s *Server) Update(ctx context.Context, request *deviceapi.UpdateRequest) (
 	if err := s.deviceStore.Store(device); err != nil {
 		return nil, err
 	}
-	log.Info("Updated Device {}", device)
+	log.Infof("Updated Device %v", device)
 	return &deviceapi.UpdateResponse{
 		Device: device,
 	}, nil

--- a/pkg/northbound/device/service.go
+++ b/pkg/northbound/device/service.go
@@ -31,7 +31,7 @@ const (
 	defaultTimeout       = 5 * time.Second
 	deviceNamePattern    = `^[a-zA-Z0-9\-:_]{4,40}$`
 	deviceAddressPattern = `^[a-zA-Z0-9\-_\.]+:[0-9]+$`
-	deviceVersionPattern = `^(\d+(\.\d+){0,3})$`
+	deviceVersionPattern = `^(\d+(\.\d+){2,3})$`
 )
 
 // NewService returns a new device Service

--- a/pkg/northbound/device/service_test.go
+++ b/pkg/northbound/device/service_test.go
@@ -82,12 +82,13 @@ func TestLocalServer(t *testing.T) {
 	assert.Contains(t, err.Error(), "device version '1.' is invalid")
 	_, err = invokeAdd(t, &client, "foobar", "foo:1234", "1.2.3.4.5")
 	assert.Contains(t, err.Error(), "device version '1.2.3.4.5' is invalid")
+	_, err = invokeAdd(t, &client, "device-foo", "device-foo:1234", "1")
+	assert.Contains(t, err.Error(), "device version '1' is invalid")
 
 	// device version accepted if valid
 	_, err = invokeAdd(t, &client, "device-foo", "device-foo:1234", "19.3.1.8")
 	assert.NoError(t, err)
-	_, err = invokeAdd(t, &client, "device-foo", "device-foo:1234", "1")
-	assert.NoError(t, err)
+
 	addResponse, err := invokeAdd(t, &client, "device-foo", "device-foo:1234", "1.0.0")
 	assert.NoError(t, err)
 	assert.NotEqual(t, deviceapi.Revision(0), addResponse.Device.Revision)

--- a/pkg/northbound/device/service_test.go
+++ b/pkg/northbound/device/service_test.go
@@ -82,9 +82,12 @@ func TestLocalServer(t *testing.T) {
 	assert.Contains(t, err.Error(), "device version '1.' is invalid")
 	_, err = invokeAdd(t, &client, "foobar", "foo:1234", "1.2.3.4.5")
 	assert.Contains(t, err.Error(), "device version '1.2.3.4.5' is invalid")
-	_, err = invokeAdd(t, &client, "foobar", "foo:1234", "19.3.1.8")
-	assert.Contains(t, err.Error(), "device version '19.3.1.8' is invalid")
 
+	// device version accepted if valid
+	_, err = invokeAdd(t, &client, "device-foo", "device-foo:1234", "19.3.1.8")
+	assert.NoError(t, err)
+	_, err = invokeAdd(t, &client, "device-foo", "device-foo:1234", "1")
+	assert.NoError(t, err)
 	addResponse, err := invokeAdd(t, &client, "device-foo", "device-foo:1234", "1.0.0")
 	assert.NoError(t, err)
 	assert.NotEqual(t, deviceapi.Revision(0), addResponse.Device.Revision)


### PR DESCRIPTION
A issue re. device-version regex is mentioned  in the `README.md` in https://github.com/onosproject/gnmi-netconf-adapter/pull/8

[Some vendors' device/model versions don't match the restrictive regex in place before this change.]
