### PR TITLE
Handle updated version on device remove events

### DIFF
--- a/test/topo/deviceservicetest.go
+++ b/test/topo/deviceservicetest.go
@@ -115,5 +115,5 @@ func (s *TestSuite) TestDeviceService(t *testing.T) {
 	eventResponse = <-events
 	assert.Equal(t, device.ListResponse_REMOVED, eventResponse.Type)
 	assert.Equal(t, device.ID("test1"), eventResponse.Device.ID)
-	assert.Equal(t, addResponse.Device.Revision, eventResponse.Device.Revision)
+	assert.True(t, eventResponse.Device.Revision > addResponse.Device.Revision)
 }


### PR DESCRIPTION
Update the topo `DeviceService` integration test to allow a change to the device revision number on delete.