### PR TITLE
Downgrade linters to work around memory consumption issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - $HOME/gopath/pkg/mod         # Cache the Go modules
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
 
 jobs:
   include:


### PR DESCRIPTION
Work around for this issue

https://github.com/golangci/golangci-lint/issues/994

