### PR TITLE
Bump version of github.com/onosproject dependencies to v0.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ export GO111MODULE=on
 .PHONY: build
 
 ONOS_TOPO_VERSION := latest
-ONOS_BUILD_VERSION := v0.6.0
-ONOS_PROTOC_VERSION := v0.6.0
+ONOS_BUILD_VERSION := v0.6.3
+ONOS_PROTOC_VERSION := v0.6.3
 
 build: # @HELP build the Go binaries and run all validations (default)
 build:

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.14
 require (
 	github.com/atomix/go-client v0.1.1
 	github.com/gogo/protobuf v1.3.1
-	github.com/onosproject/helmit v0.6.0
-	github.com/onosproject/onos-lib-go v0.6.2
+	github.com/onosproject/helmit v0.6.3
+	github.com/onosproject/onos-lib-go v0.6.3
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/viper v1.6.2 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -518,10 +518,10 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/onosproject/helmit v0.6.0 h1:4MVgYP8nf/+6SNMxTcYOKsSIVrLt8y0Z+ae+Felc1P4=
-github.com/onosproject/helmit v0.6.0/go.mod h1:ZvjMu26Kd19hCHzkpnUH1Zgv/htt7iZbPG1EsFXBlhc=
-github.com/onosproject/onos-lib-go v0.6.2 h1:ku/0U1Mzh2NufLaoBSl0nxeiwx1Mg5EMuoPMfxD/S6I=
-github.com/onosproject/onos-lib-go v0.6.2/go.mod h1:5YjAEEoqqZR0EYWkV1CxyP7XwOqDXFbeJpmGnYixG+I=
+github.com/onosproject/helmit v0.6.3 h1:BIyU16afl+3ujyjbqL590KAPdjYK7oUHH86dNJUeyQk=
+github.com/onosproject/helmit v0.6.3/go.mod h1:ZvjMu26Kd19hCHzkpnUH1Zgv/htt7iZbPG1EsFXBlhc=
+github.com/onosproject/onos-lib-go v0.6.3 h1:AZNmgWssNxQiJWg5RrrFiAOmevMY+poNBwgBMAc/JeY=
+github.com/onosproject/onos-lib-go v0.6.3/go.mod h1:5YjAEEoqqZR0EYWkV1CxyP7XwOqDXFbeJpmGnYixG+I=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=


### PR DESCRIPTION
Updating: github.com/onosproject/helmit to v0.6.3
Updating: github.com/onosproject/onos-lib-go to v0.6.3