### PR TITLE
Bulk load: requires relationship to specify a source and target

### DIFF
--- a/pkg/bulk/topo-load-entities-example.yaml
+++ b/pkg/bulk/topo-load-entities-example.yaml
@@ -40,6 +40,11 @@ toporelationships:
     obj:
       relationship:
         type: 6
+        directionality: 2
+        sourceref:
+          id: "315010-0001420"
+        targetref:
+          id: "315010-0001421"
     attrs:
       attrs:
         displayname: "Tower 1 - Tower 2"

--- a/pkg/bulk/topo.go
+++ b/pkg/bulk/topo.go
@@ -104,6 +104,12 @@ func TopoChecker(config *TopoConfig) error {
 			return fmt.Errorf("unexpected type %v for TopoRelationship", topoRelationship.Type)
 		} else if topoRelationship.Ref == nil || topoRelationship.Ref.GetID() == "" {
 			return fmt.Errorf("empty ref for TopoRelationship")
+		} else if topoRelationship.Obj.Relationship.SourceRef == nil ||
+			topoRelationship.Obj.Relationship.SourceRef.ID == "" {
+			return fmt.Errorf("empty source ref for TopoRelationship")
+		} else if topoRelationship.Obj.Relationship.TargetRef == nil ||
+			topoRelationship.Obj.Relationship.TargetRef.ID == "" {
+			return fmt.Errorf("empty target ref for TopoRelationship")
 		}
 	}
 

--- a/pkg/bulk/topo_test.go
+++ b/pkg/bulk/topo_test.go
@@ -39,6 +39,9 @@ func Test_LoadConfig2(t *testing.T) {
 	rel1 := config.TopoRelationships[0]
 	assert.Equal(t, topo.Object_RELATIONSHIP, rel1.Type)
 	assert.Equal(t, topo.Relationship_TRAVERSES, rel1.Obj.Relationship.GetType())
+	assert.Equal(t, topo.Relationship_BIDIRECTIONAL, rel1.Obj.Relationship.GetDirectionality())
+	assert.Equal(t, topo.ID("315010-0001420"), rel1.Obj.Relationship.GetSourceRef().GetID())
+	assert.Equal(t, topo.ID("315010-0001421"), rel1.Obj.Relationship.GetTargetRef().GetID())
 	assert.Equal(t, topo.ID("rel1"), rel1.Ref.GetID())
 	displayname, ok := rel1.Attrs.GetAttrs()["displayname"]
 	assert.Assert(t, ok, "error extracting displayname")


### PR DESCRIPTION
@shadansari  to run the bulk load command - I ran it from my PC directly

Expose onos-topo to local machine
```bash
kubectl -n micro-onos port-forward $(kubectl -n micro-onos get pods -l type=topo -o name) 5150
```

Temporarily patch onos-cli `go.mod` with
```go
replace (
       github.com/onosproject/onos-cli/pkg/sdrancli => ./pkg/sdrancli
       github.com/onosproject/onos-ric => ../onos-ric
)
```

Then get the latest topo go module (from inside `onos-cli` directory)
```bash
go get github.com/onosproject/onos-topo@master
```

Copy the sample YAML over to your `onos-cli` directory, and run the command from there:
```bash
go run ./cmd/onos topo load yamlentities topo-load-entities-example.yaml --service-address localhost:5150
```

you should get
```
Loaded 2 topo devices from topo-load-entities-example.yaml
```

I am seeing `onos-topo` crash at this though with
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe2eede]

goroutine 148 [running]:
github.com/onosproject/onos-topo/pkg/northbound/topo.(*Server).Load(0xc000399410, 0x0, 0x11db360, 0xc000684780, 0xc00019e3a0)
	/go/src/github.com/onosproject/onos-topo/pkg/northbound/topo/service.go:207 +0x2e
github.com/onosproject/onos-topo/pkg/northbound/topo.(*Server).ValidateRelationship(0xc000399410, 0xc00000eb00, 0x0, 0x0)
	/go/src/github.com/onosproject/onos-topo/pkg/northbound/topo/service.go:194 +0x3d
github.com/onosproject/onos-topo/pkg/northbound/topo.(*Server).Write(0xc000399410, 0x11db3a0, 0xc000187380, 0xc00000eac0, 0xc000399410, 0xc000187380, 0xc00058db78)
	/go/src/github.com/onosproject/onos-topo/pkg/northbound/topo/service.go:85 +0x107
github.com/onosproject/onos-topo/api/topo._Topo_Write_Handler(0xfb47a0, 0xc000399410, 0x11db3a0, 0xc000187380, 0xc0006844e0, 0x0, 0x11db3a0, 0xc000187380, 0xc00051c400, 0x1fa)
	/go/src/github.com/onosproject/onos-topo/api/topo/topo.pb.go:994 +0x217
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003a9500, 0x11e40e0, 0xc0005b2600, 0xc000586200, 0xc00043a300, 0x1972860, 0x0, 0x0, 0x0)
	/go/src/github.com/onosproject/onos-topo/vendor/google.golang.org/grpc/server.go:1024 +0x501
google.golang.org/grpc.(*Server).handleStream(0xc0003a9500, 0x11e40e0, 0xc0005b2600, 0xc000586200, 0x0)
	/go/src/github.com/onosproject/onos-topo/vendor/google.golang.org/grpc/server.go:1313 +0xd3d
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000590b90, 0xc0003a9500, 0x11e40e0, 0xc0005b2600, 0xc000586200)
	/go/src/github.com/onosproject/onos-topo/vendor/google.golang.org/grpc/server.go:722 +0xa1
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/src/github.com/onosproject/onos-topo/vendor/google.golang.org/grpc/server.go:720 +0xa1
```